### PR TITLE
Changed ownership \app directory to appuser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN adduser \
     --uid "${UID}" \
     appuser
 
+# Change the ownership of the /app directory to appuser    
+RUN chown appuser:appuser /app            
+
 # Download dependencies as a separate step to take advantage of Docker's caching.
 # Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
 # Leverage a bind mount to requirements.txt to avoid having to copy them into


### PR DESCRIPTION
Made appuser the owner of folder /app to fix the issue `PermissionError: [Errno 13] Permission denied: 'faiss_index' ` which occurs when faiss tries to create a folder to save vectors during the processing of the pdf file.