### PR TITLE
FAISS.load_local requires allow_dangerous_deserialization=True to run

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,7 +73,7 @@ def user_input(user_question):
     embeddings = GoogleGenerativeAIEmbeddings(
         model="models/embedding-001")  # type: ignore
 
-    new_db = FAISS.load_local("faiss_index", embeddings)
+    new_db = FAISS.load_local("faiss_index", embeddings, allow_dangerous_deserialization=True) 
     docs = new_db.similarity_search(user_question)
 
     chain = get_conversational_chain()


### PR DESCRIPTION
This solves this error:

ValueError: The de-serialization relies loading a pickle file. Pickle files can be modified to deliver a malicious payload that results in execution of arbitrary code on your machine.You will need to set `allow_dangerous_deserialization` to `True` to enable deserialization. If you do this, make sure that you trust the source of the data. For example, if you are loading a file that you created, and no that no one else has modified the file, then this is safe to do. Do not set this to `True` if you are loading a file from an untrusted source (e.g., some random site on the internet.). Traceback:
File "/usr/local/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 542, in _run_script
    exec(code, module.__dict__)
File "/app/app.py", line 144, in <module>
    main()
File "/app/app.py", line 131, in main
    response = user_input(prompt)
File "/app/app.py", line 76, in user_input
    new_db = FAISS.load_local("faiss_index", embeddings)
File "/usr/local/lib/python3.10/site-packages/langchain_community/vectorstores/faiss.py", line 1078, in load_local
    raise ValueError(